### PR TITLE
Updated OpenGeospatial Link

### DIFF
--- a/en/development/rfc/ms-rfc-13.txt
+++ b/en/development/rfc/ms-rfc-13.txt
@@ -36,7 +36,7 @@ This is the a first attempt to support part of the OGC Sensor Web Enablement
 
 
 The intention here is to support the SOS mandatory operations.  
-Please refer to the OGC site (http://www.opengeospatial.org/functional/?page=swe) 
+Please refer to the OGC site (http://www.opengeospatial.org/) 
 for more details on the SWE initiatives.
 
 User Interface


### PR DESCRIPTION
Hi Guys This link is no longer exist. Not found Error 403 
Link is this :- http://www.opengeospatial.org/functional/?page=swe
So I have removed the older one and added the correct.
Here is the corrected link :-http://www.opengeospatial.org/